### PR TITLE
Draw circle around each card only if circle_width_pix is not 0

### DIFF
--- a/dobble/card.py
+++ b/dobble/card.py
@@ -339,8 +339,9 @@ def generate_card(out_card_path: str,
 
         cropped_card_img[cropped_resized_mask] = cropped_resized_symbol[cropped_resized_mask]
 
-    cv2.circle(card_img, (card_size_pix // 2, card_size_pix // 2),
-               card_size_pix // 2, (0, 0, 0), circle_width_pix)
+    if circle_width_pix != 0:
+        cv2.circle(card_img, (card_size_pix // 2, card_size_pix // 2),
+                card_size_pix // 2, (0, 0, 0), circle_width_pix)
     cv2.imwrite(out_card_path, card_img)
 
     if DEBUG_FINAL:


### PR DESCRIPTION
Hello again @ThomasParistech 

When printing, I was happy to have the small circle around the cards to use with my scissor. But it was a very slow process, so for the following dobble, I invested in a "circle punch". It is much more efficient but also harder to match the black circle. In this PR I propose to let the user to completely remove the circle if needed using the already existing `circle_width_pix` to 0.

```bash
python3 -m dobble --symbols_folder images/symbols_examples/ --output_folder result --circle_width_pix 0
```

![image](https://github.com/user-attachments/assets/a20dc496-7ec0-4bb7-89b1-fd07cce5448f)
