### PR TITLE
Fixes for junior mode, and for using SVGs as input

### DIFF
--- a/dobble/__main__.py
+++ b/dobble/__main__.py
@@ -50,6 +50,7 @@ def main(symbols_folder: str,
 
     new_folder(output_folder)
 
+    svg2png_folder = os.path.join(output_folder, "0_svg2png")
     square_symbols_folder = os.path.join(output_folder, "1_square_symbols")
     masks_folder = os.path.join(output_folder, "2_masks")
     cards_folder = os.path.join(output_folder, "3_cards")
@@ -60,6 +61,7 @@ def main(symbols_folder: str,
     with LogScopeTime("Preprocessing"):
         preprocess.main(images_folder=symbols_folder,
                         out_images_folder=square_symbols_folder,
+                        svg2png_folder=svg2png_folder,
                         out_masks_folder=masks_folder,
                         mask_computing_size_pix=mask_computing_size_pix,
                         mask_low_res_size_pix=mask_low_res_size_pix,

--- a/dobble/utils.py
+++ b/dobble/utils.py
@@ -33,7 +33,7 @@ def assert_len(seq: Sized, size: int, *, msg: str = ""):
 
 def list_image_files(images_folder: str) -> List[str]:
     """List image files."""
-    image_extensions = ('.jpg', '.jpeg', '.png', '.gif', '.bmp', '.tiff')
+    image_extensions = ('.jpg', '.jpeg', '.png', '.gif', '.bmp', '.tiff', '.svg')
     return [f.name
             for f in os.scandir(images_folder)
             if f.name.lower().endswith(image_extensions)]


### PR DESCRIPTION
I ran into two issues when trying to use this project: the recent validation that there are exactly 57 images in the directory is incorrect when trying to produce a Junior version (which requires exactly 31 images).

Also, I created `.svg` files of those images, and while there _was_ some code to convert those to `.png` files, it wrote those into the same directory, messing up the validation logic (which now counted _both_ `.svg` and `.png` files).

Obviously, an even better solution would be to use the `.svg` images directly to produce a super small `.pdf` file, but I did not see any way to force the `img2pdf` package to do that.